### PR TITLE
Adding "Mark Gone" capability to effectively remove a slug.

### DIFF
--- a/-/index.php
+++ b/-/index.php
@@ -550,7 +550,24 @@ else if(isset($_GET['stats']))  // Display stats
 }
 elseif(isset($_GET['mark_gone']) && isset($_GET['slug']) && strlen(trim($_GET['slug']))) 
 { // Mark a redirection as GONE
-	// TODO
+	$prefix = DB_PREFIX;
+	$slug = $_GET['slug'];
+
+	// Check if slug is in use
+	$stmt = $db->prepare("SELECT url, checksum, custom_url, redir_type FROM {$prefix}urls WHERE BINARY custom_url = BINARY :slug AND custom_url = :slug");
+	$stmt->execute(array('slug'=>$slug));
+	$row = $stmt->fetch(PDO::FETCH_ASSOC);
+	if($row){ // slug exists
+		$result = bcurls_update_slug($row['url'], $row['checksum'], $row['custom_url'], 'gone');
+		if($result !== true) {
+			$error = $insert_result;
+			include('pages/error.php');
+			exit;
+		}
+	}
+	// Redirect to the stats page
+	header('Location:?stats=1');
+	exit();
 }
 else
 {

--- a/-/pages/stats.php
+++ b/-/pages/stats.php
@@ -7,6 +7,8 @@
 		<th>URL</th>
 		<th>Lessn'd</th>
 		<th>Hits</th>
+		<th>Active?</th>
+		<th>Mark Gone</th>
 	</tr>
 	
 <?php foreach($top_urls as $url) { 
@@ -16,6 +18,8 @@
 		<td><?php echo htmlspecialchars($url['url'], ENT_QUOTES, 'UTF-8')?></td>
 		<td><!-- <a href="<?php /*=$short*/ ?>"> --><?php echo $short?><!-- </a> --></td>
 		<td><?php echo $url['hits']?></td>
+		<td><?php echo $url['redir_type'] == 'gone' ? 'Gone' : 'Active'; ?></td>
+		<td><?php if($url['redir_type'] != 'gone'){ ?><a href="?mark_gone=1&slug=<?php echo $url['custom_url']; ?>">Mark Gone</a><?php } ?></td>
 	</tr>
 <?php } ?>
 

--- a/-/stats.php
+++ b/-/stats.php
@@ -10,7 +10,7 @@ function record_stats($db, $url_id) {
 }
 
 function stats_top_urls($db, $count=10) {
-	$stmt = $db->query('SELECT u.id,u.url,u.custom_url,COUNT(s.url_id) as hits FROM '.DB_PREFIX.'urls u LEFT JOIN '.DB_PREFIX.'url_stats s ON u.id = s.url_id GROUP BY u.id,u.url ORDER BY hits desc LIMIT '.$count);
+	$stmt = $db->query('SELECT u.id,u.url,u.custom_url,u.redir_type,COUNT(s.url_id) as hits FROM '.DB_PREFIX.'urls u LEFT JOIN '.DB_PREFIX.'url_stats s ON u.id = s.url_id GROUP BY u.id,u.url ORDER BY hits desc LIMIT '.$count);
 	return $stmt->fetchAll(PDO::FETCH_ASSOC);
 }
 


### PR DESCRIPTION
Enhances Lessnmore to have "Mark Gone" support. This was already demarcated in index.php, but wasn't functional.

I've added this to the Stats page for administration and implemented the TODO.
